### PR TITLE
Added ability to override maxValue for line and bar charts

### DIFF
--- a/Source/YOChartImageKit/YOBarChartImage.h
+++ b/Source/YOChartImageKit/YOBarChartImage.h
@@ -30,6 +30,12 @@ typedef NS_ENUM(NSInteger, YOBarChartImageBarStyle){
 @property (nonnull) NSArray<NSNumber *> *values;
 
 /**
+ *  The maximum value to use for the chart. Setting this will override the 
+ *  default behavior of using the highest value as maxValue.
+ */
+@property NSNumber* maxValue;
+
+/**
  *  The style of the bar chart.
  */
 @property YOBarChartImageBarStyle barStyle;

--- a/Source/YOChartImageKit/YOBarChartImage.h
+++ b/Source/YOChartImageKit/YOBarChartImage.h
@@ -33,7 +33,7 @@ typedef NS_ENUM(NSInteger, YOBarChartImageBarStyle){
  *  The maximum value to use for the chart. Setting this will override the 
  *  default behavior of using the highest value as maxValue.
  */
-@property NSNumber* maxValue;
+@property (nonnull, nonatomic) NSNumber* maxValue;
 
 /**
  *  The style of the bar chart.

--- a/Source/YOChartImageKit/YOBarChartImage.m
+++ b/Source/YOChartImageKit/YOBarChartImage.m
@@ -17,6 +17,10 @@
     return self;
 }
 
+- (NSNumber *) maxValue {
+    return _maxValue ? _maxValue : [NSNumber numberWithFloat:[[_values valueForKeyPath:@"@max.floatValue"] floatValue]];
+}
+
 const CGFloat kBarPaddingMultipler = 20.0f;
 
 - (UIImage *)drawImage:(CGRect)frame scale:(CGFloat)scale {

--- a/Source/YOChartImageKit/YOBarChartImage.m
+++ b/Source/YOChartImageKit/YOBarChartImage.m
@@ -22,7 +22,7 @@ const CGFloat kBarPaddingMultipler = 20.0f;
 - (UIImage *)drawImage:(CGRect)frame scale:(CGFloat)scale {
     NSAssert(_values.count > 0, @"YOBarChartImage // must assign values property which is an array of NSNumber");
 
-    CGFloat maxValue = [[_values valueForKeyPath:@"@max.floatValue"] floatValue];
+    CGFloat maxValue = _maxValue ? [_maxValue floatValue] : [[_values valueForKeyPath:@"@max.floatValue"] floatValue];
     CGFloat dataCount = (CGFloat)_values.count;
 
     CGFloat padding;

--- a/Source/YOChartImageKit/YOLineChartImage.h
+++ b/Source/YOChartImageKit/YOLineChartImage.h
@@ -17,7 +17,7 @@
  *  The maximum value to use for the chart. Setting this will override the
  *  default behavior of using the highest value as maxValue.
  */
-@property NSNumber* maxValue;
+@property (nonnull, nonatomic) NSNumber* maxValue;
 
 /**
  *  The width of chart's stroke. 

--- a/Source/YOChartImageKit/YOLineChartImage.h
+++ b/Source/YOChartImageKit/YOLineChartImage.h
@@ -14,6 +14,12 @@
 @property (nonnull) NSArray<NSNumber *> *values;
 
 /**
+ *  The maximum value to use for the chart. Setting this will override the
+ *  default behavior of using the highest value as maxValue.
+ */
+@property NSNumber* maxValue;
+
+/**
  *  The width of chart's stroke. 
  *  The default width is `1.0`.
  */

--- a/Source/YOChartImageKit/YOLineChartImage.m
+++ b/Source/YOChartImageKit/YOLineChartImage.m
@@ -18,7 +18,7 @@
     NSUInteger valuesCount = _values.count;
     CGFloat pointX = frame.size.width / (valuesCount - 1);
     NSMutableArray<NSValue *> *points = [NSMutableArray array];
-    CGFloat maxValue = [[_values valueForKeyPath:@"@max.floatValue"] floatValue];
+    CGFloat maxValue = _maxValue ? [_maxValue floatValue] : [[_values valueForKeyPath:@"@max.floatValue"] floatValue];
 
     [_values enumerateObjectsUsingBlock:^(NSNumber *number, NSUInteger idx, BOOL *_) {
         CGFloat ratioY = number.floatValue / maxValue;

--- a/Source/YOChartImageKit/YOLineChartImage.m
+++ b/Source/YOChartImageKit/YOLineChartImage.m
@@ -12,6 +12,10 @@
     return self;
 }
 
+- (NSNumber *) maxValue {
+    return _maxValue ? _maxValue : [NSNumber numberWithFloat:[[_values valueForKeyPath:@"@max.floatValue"] floatValue]];
+}
+
 - (UIImage *)drawImage:(CGRect)frame scale:(CGFloat)scale {
     NSAssert(_values.count > 0, @"YOLineChartImage // must assign values property which is an array of NSNumber");
     


### PR DESCRIPTION
Setting maxValue overrides default behavior of using the highest value
as the max y value for the charts.
